### PR TITLE
Add loading bar for genre and beat changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@angular/core": "^17.3.11",
         "@angular/platform-browser": "^17.3.11",
         "@angular/platform-browser-dynamic": "^17.3.11",
+        "@ngx-loading-bar/core": "^7.0.0",
         "angular-in-memory-web-api": "^0.17.0",
         "eslint": "^8.10.0",
         "rxjs": "~7.5.0",
@@ -4659,6 +4660,19 @@
         "@angular/compiler-cli": "^17.0.0",
         "typescript": ">=5.2 <5.5",
         "webpack": "^5.54.0"
+      }
+    },
+    "node_modules/@ngx-loading-bar/core": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@ngx-loading-bar/core/-/core-7.0.0.tgz",
+      "integrity": "sha512-+YXS+oAXcNf4DGCnZbcgn5EkqTl1qceY/zP7GlVVadVVJab73dzVAss0EnKrh0KENX9R3O83CRciOshTYyG6DQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": ">=16.0.0",
+        "rxjs": "^7.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -21030,6 +21044,14 @@
       "integrity": "sha512-CjSVVa/9fzMpEDQP01SC4colKCbZwj7vUq0H2bivp8jVsmd21x9Fu0gDBH0Y9NdfAIm4eGZvmiZKMII3vIOaYQ==",
       "dev": true,
       "requires": {}
+    },
+    "@ngx-loading-bar/core": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@ngx-loading-bar/core/-/core-7.0.0.tgz",
+      "integrity": "sha512-+YXS+oAXcNf4DGCnZbcgn5EkqTl1qceY/zP7GlVVadVVJab73dzVAss0EnKrh0KENX9R3O83CRciOshTYyG6DQ==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@angular/core": "^17.3.11",
     "@angular/platform-browser": "^17.3.11",
     "@angular/platform-browser-dynamic": "^17.3.11",
+    "@ngx-loading-bar/core": "^7.0.0",
     "angular-in-memory-web-api": "^0.17.0",
     "eslint": "^8.10.0",
     "rxjs": "~7.5.0",

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,3 +1,4 @@
+<ngx-loading-bar></ngx-loading-bar>
 <ng-container *ngIf="!isMobileDisplay">
   <main class="flex app-container">
     <nav class="flex column left-menu">

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -6,11 +6,15 @@ import { HttpClientInMemoryWebApiModule } from 'angular-in-memory-web-api';
 import {InMemoryDataService} from "./adapters/secondary/in-memory-data.service";
 import {SequencerComponent} from "./components/sequencer/sequencer.component";
 import {GenresAdapterService} from "./adapters/secondary/genres-adapter.service";
+import { LoadingBarModule } from '@ngx-loading-bar/core';
+import { HTTP_INTERCEPTORS } from '@angular/common/http';
+import { LoadingInterceptor } from './interceptors/loading.interceptor';
 
 @NgModule({
   imports: [
     BrowserModule,
     HttpClientModule,
+    LoadingBarModule,
 
     // The HttpClientInMemoryWebApiModule module intercepts HTTP requests
     // and returns simulated server responses.
@@ -23,7 +27,8 @@ import {GenresAdapterService} from "./adapters/secondary/genres-adapter.service"
   declarations: [AppComponent],
   providers: [
     // Inject adapters into domain classes
-    {provide: 'IManageGenres', useClass: GenresAdapterService}
+    {provide: 'IManageGenres', useClass: GenresAdapterService},
+    { provide: HTTP_INTERCEPTORS, useClass: LoadingInterceptor, multi: true },
   ],
   bootstrap: [AppComponent]
 })

--- a/src/app/interceptors/loading.interceptor.ts
+++ b/src/app/interceptors/loading.interceptor.ts
@@ -8,7 +8,7 @@ import { finalize } from 'rxjs/operators';
 export class LoadingInterceptor implements HttpInterceptor {
   constructor(private loader: LoadingBarService) {}
 
-  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+  intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
     this.loader.start();
     return next.handle(req).pipe(finalize(() => this.loader.complete()));
   }

--- a/src/app/interceptors/loading.interceptor.ts
+++ b/src/app/interceptors/loading.interceptor.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { HttpInterceptor, HttpRequest, HttpHandler, HttpEvent } from '@angular/common/http';
+import { LoadingBarService } from '@ngx-loading-bar/core';
+import { Observable } from 'rxjs';
+import { finalize } from 'rxjs/operators';
+
+@Injectable()
+export class LoadingInterceptor implements HttpInterceptor {
+  constructor(private loader: LoadingBarService) {}
+
+  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    this.loader.start();
+    return next.handle(req).pipe(finalize(() => this.loader.complete()));
+  }
+}


### PR DESCRIPTION
This PR addresses issue #91 by implementing a loading bar to enhance user experience during genre and beat changes. The loading bar appears while waiting for sound files to load, providing visual feedback to the user. I tested the changes by switching genres and beats to ensure the loading bar displays correctly.

Please review the changes and let me know if you have any feedback. Thank you!