### PR TITLE
Linter : Remove no return void and at least one parameter warning

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -72,14 +72,6 @@ export default [
       'functional/prefer-tacit': 'off',
       'functional/no-conditional-statements': 'off', // Too strict for Angular
       'functional/no-expression-statements': 'off', // Angular needs side effects
-      'functional/functional-parameters': ['warn', {
-        'allowRestParameter': true,
-        'allowArgumentsKeyword': false,
-      }],
-      'functional/no-return-void': ['warn', {
-        'allowNull': true,
-        'allowUndefined': true,
-      }],
       'functional/prefer-property-signatures': 'warn',
       'functional/type-declaration-immutability': 'warn',
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Relaxed TypeScript/Angular linting by removing two functional constraints, allowing rest parameters and certain void returns without warnings.
  - Improves developer experience by reducing false positives and friction during development and code review.
  - No changes to application behavior, performance, or user-facing features.
  - Build output remains unchanged; existing workflows continue to work as before.
  - No documentation updates required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->