### PR TITLE
Update hip-hop beat metadata

### DIFF
--- a/frontend/src/assets/beats/beats-metadata.json
+++ b/frontend/src/assets/beats/beats-metadata.json
@@ -5,6 +5,11 @@
         "label": "(new) Hip-Hop: double kick offset"
     },
     {
+        "filename": "hip-hop/boom-bap",
+        "genre": "Hip-Hop",
+        "label": "Boom Bap"
+    },
+    {
         "filename": "hip-hop/trap",
         "genre": "Hip-Hop",
         "label": "Trap"


### PR DESCRIPTION
 Updated the Hip-Hop beat metadata by correcting the track label and beat information in `beats-metadata.json`. This ensures the Boom Bap and Hip-Hop tracks are displayed with the correct names and metadata.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Boom Bap beat to the available Hip-Hop music collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->