### PR TITLE
571 refacto rewrite tempo adapter service

### DIFF
--- a/frontend/src/app/infrastructure/adapters/tempo-control/tempo-adapter.service.spec.ts
+++ b/frontend/src/app/infrastructure/adapters/tempo-control/tempo-adapter.service.spec.ts
@@ -19,48 +19,48 @@ describe('Tempo service', () => {
   cases.forEach(({ tempo, beatsPerBar, subdivisionsPerBeat, expectedStepDuration }) => {
     const service = new TempoAdapterService();
     it(`${subdivisionsPerBeat * beatsPerBar} steps long track at ${tempo} BPM should be ${expectedStepDuration} step long because it does not depends on step number`, () => {
-      service.setBeatsPerBar(beatsPerBar);
-      service.setSubdivisionsPerBeat(subdivisionsPerBeat);
-      service.setBpm(tempo);
+      service.beatsPerBar = beatsPerBar;
+      service.subdivisionsPerBeat = subdivisionsPerBeat;
+      service.bpm = tempo;
       expect(service.stepDuration).toBe(expectedStepDuration);
     });
   });
 
   it('recalculates numberOfSteps when subdivisionsPerBeat is set before beatsPerBar', () => {
     const service = new TempoAdapterService();
-    service.setSubdivisionsPerBeat(3);
-    service.setBeatsPerBar(4);
+    service.subdivisionsPerBeat = 3;
+    service.beatsPerBar = 4;
     expect(service.numberOfSteps).toBe(12);
   });
 
   it('recalculates numberOfSteps and supports 64-step tracks', () => {
     const service = new TempoAdapterService();
-    service.setBeatsPerBar(16);
-    service.setSubdivisionsPerBeat(4);
+    service.beatsPerBar = 16;
+    service.subdivisionsPerBeat = 4;
     expect(service.numberOfSteps).toBe(64);
   });
 
   it('supports 32-step patterns with two bars', () => {
     const service = new TempoAdapterService();
-    service.setBeatsPerBar(4);
-    service.setSubdivisionsPerBeat(4);
-    service.setNumberOfBar(2);
+    service.beatsPerBar = 4;
+    service.subdivisionsPerBeat = 4;
+    service.numberOfBar= 2;
     expect(service.numberOfSteps).toBe(32);
   });
 
   it('supports 64-step patterns with four bars', () => {
     const service = new TempoAdapterService();
-    service.setBeatsPerBar(4);
-    service.setSubdivisionsPerBeat(4);
-    service.setNumberOfBar(4);
+    service.beatsPerBar = 4;
+    service.subdivisionsPerBeat = 4;
+    service.numberOfBar= 4;
     expect(service.numberOfSteps).toBe(64);
   });
 
   it('keeps a single bar as 16 steps by default', () => {
     const service = new TempoAdapterService();
-    service.setBeatsPerBar(4);
-    service.setSubdivisionsPerBeat(4);
-    service.setNumberOfBar(1);
+    service.beatsPerBar = 4;
+    service.subdivisionsPerBeat = 4;
+    service.numberOfBar= 1;
     expect(service.numberOfSteps).toBe(16);
   });
 });

--- a/frontend/src/app/infrastructure/adapters/tempo-control/tempo-adapter.service.ts
+++ b/frontend/src/app/infrastructure/adapters/tempo-control/tempo-adapter.service.ts
@@ -31,12 +31,9 @@ export class TempoAdapterService {
       this.beatsPerBar * this.subdivisionsPerBeat * this.numberOfBar
     );
 
+    //TODO : Try removing the default 16 but imo there is a throw at the app opening
     if (!steps) {
-      throw new Error(
-        `Unsupported step count: ${
-          this.beatsPerBar * this.subdivisionsPerBeat * this.numberOfBar
-        }`
-      );
+      return NumberOfSteps.sixteen;
     }
 
     return steps;

--- a/frontend/src/app/infrastructure/adapters/tempo-control/tempo-adapter.service.ts
+++ b/frontend/src/app/infrastructure/adapters/tempo-control/tempo-adapter.service.ts
@@ -6,74 +6,57 @@ import { StepIndex } from "../../../domain/step-index";
 
 const numberOfSecondsInOneMinute = 60;
 
+const NUMBER_OF_STEPS_MAP: ReadonlyMap<number, NumberOfSteps> =
+  new Map<number, NumberOfSteps>([
+    [8, NumberOfSteps.eight],
+    [12, NumberOfSteps.twelve],
+    [16, NumberOfSteps.sixteen],
+    [24, NumberOfSteps.twenty_four],
+    [32, NumberOfSteps.thirty_two],
+    [48, NumberOfSteps.forty_eight],
+    [64, NumberOfSteps.sixty_four]
+  ]);
+
 @Injectable({
   providedIn: "root"
 })
 export class TempoAdapterService {
   public bpm = BPM(128);
-  public numberOfSteps = 16;
   public beatsPerBar = 4;
   public subdivisionsPerBeat = 4;
   public numberOfBar = 1;
 
-  setBpm(bpm: BPM) {
-    this.bpm = bpm;
-  }
+  get numberOfSteps(): NumberOfSteps {
+    const steps = NUMBER_OF_STEPS_MAP.get(
+      this.beatsPerBar * this.subdivisionsPerBeat * this.numberOfBar
+    );
 
-  setBeatsPerBar(beatsPerBar: number) {
-    this.beatsPerBar = beatsPerBar;
-    this.recalculateNumberOfSteps();
-  }
-
-  setSubdivisionsPerBeat(subdivisionsPerBeat: number) {
-    this.subdivisionsPerBeat = subdivisionsPerBeat;
-    this.recalculateNumberOfSteps();
-  }
-
-  setNumberOfBar(numberOfBar: number) {
-    this.numberOfBar = numberOfBar;
-    this.recalculateNumberOfSteps();
-  }
-
-  private recalculateNumberOfSteps() {
-    if (Number.isNaN(this.subdivisionsPerBeat))
-      throw new Error(`subdivisionsPerBeat is NaN`);
-
-    this.numberOfSteps = this.mapNumberOfSteps(this.beatsPerBar * this.subdivisionsPerBeat * this.numberOfBar);
-  }
-
-  private mapNumberOfSteps(product: number): NumberOfSteps {
-    switch (product) {
-      case 8:
-        return NumberOfSteps.eight;
-      case 12:
-        return NumberOfSteps.twelve;
-      case 16:
-        return NumberOfSteps.sixteen;
-      case 24:
-        return NumberOfSteps.twenty_four;
-      case 32:
-        return NumberOfSteps.thirty_two;
-      case 48:
-        return NumberOfSteps.forty_eight;
-      case 64:
-        return NumberOfSteps.sixty_four;
-      default:
-        throw new Error(`Unsupported number of steps: ${product}`);
+    if (!steps) {
+      throw new Error(
+        `Unsupported step count: ${
+          this.beatsPerBar * this.subdivisionsPerBeat * this.numberOfBar
+        }`
+      );
     }
+
+    return steps;
   }
 
   get stepDuration(): Seconds {
-    return Seconds(numberOfSecondsInOneMinute / this.bpm / this.subdivisionsPerBeat);
+    return Seconds(
+      numberOfSecondsInOneMinute /
+      this.bpm /
+      this.subdivisionsPerBeat
+    );
   }
 
   get barDuration(): Seconds {
     return Seconds(this.stepDuration * this.numberOfSteps);
   }
 
-  /** Pure math: given a time offset in seconds, where does a step fall? */
   getNextStepTime(baseTime: Seconds, stepIndex: StepIndex): number {
     const bar = Math.floor(baseTime / this.barDuration);
+
     return bar * this.barDuration + stepIndex * this.stepDuration;
   }
 }

--- a/frontend/src/app/ui/components/sequencer/sequencer.component.ts
+++ b/frontend/src/app/ui/components/sequencer/sequencer.component.ts
@@ -81,7 +81,7 @@ export class SequencerComponent implements OnInit, OnDestroy {
           if (!state)
             return;
 
-          this.tempoService.setBpm(BPM(state.tempo));
+          this.tempoService.bpm = BPM(state.tempo);
 
           const beatMeta =
             this.sequencerService.genres
@@ -94,9 +94,9 @@ export class SequencerComponent implements OnInit, OnDestroy {
             } else {
               this._applyBeat(beatMeta, state.genre, state.tempo, state.beatsPerBar, state.subdivisionsPerBeat, state.numberOfBars);
 
-              this.tempoService.setBeatsPerBar(state.beatsPerBar ?? 4);
-              this.tempoService.setSubdivisionsPerBeat(state.subdivisionsPerBeat);
-              this.tempoService.setNumberOfBar(state.numberOfBars ?? 1);
+              this.tempoService.beatsPerBar = state.beatsPerBar ?? 4;
+              this.tempoService.subdivisionsPerBeat = state.subdivisionsPerBeat;
+              this.tempoService.numberOfBar = state.numberOfBars ?? 1;
             }
           }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sequencer timing calculations across different beat, subdivision, and bar configurations.
  - Unsupported timing combinations now fall back to 16 steps instead of causing an error.

- **Refactor**
  - Simplified tempo and sequencing configuration while preserving existing BPM, duration, and step progression behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->