### PR TITLE
Fix/432 mobile sequencer scroll

### DIFF
--- a/frontend/src/app/ui/components/sequencer/sequencer.component.html
+++ b/frontend/src/app/ui/components/sequencer/sequencer.component.html
@@ -35,7 +35,8 @@
       </app-select-input>
     </div>
   </div>
-  <div class="tracks-name-container">
+  <div #sequencerScrollContainer class="sequencer-scroll-container">
+    <div class="tracks-name-container">
     @for (track of beat.tracks; track track){
     <div class="tracks-name">
       <button class="button square-button" title="Play sample" (mousedown)="soundService.playTrack(track.name)">
@@ -57,8 +58,8 @@
       </div>
     </div>
     }
-  </div>
-  <section class="tracks-container">
+    </div>
+    <section class="tracks-container">
     @for (track of beat.tracks; track $index) {
     <article>
       <div id="track" [class.eight-steps]="track.steps.steps.length == NumberOfSteps.eight"
@@ -83,7 +84,8 @@
       </div>
     </article>
     }
-  </section>
+    </section>
+  </div>
   <section class="export-button-container flex">
     <button class="button" (click)="isAudioExportModalOpen = true">{{ 'export.wavButton' | translate
       }}</button>

--- a/frontend/src/app/ui/components/sequencer/sequencer.component.scss
+++ b/frontend/src/app/ui/components/sequencer/sequencer.component.scss
@@ -142,6 +142,10 @@ $gap: 4px;
   overflow-x: auto;
 }
 
+.sequencer-scroll-container {
+  display: contents;
+}
+
 .tracks-name-container {
   grid-column-start: 1;
   grid-row-start: 2;
@@ -161,6 +165,52 @@ $gap: 4px;
     .track-name {
       white-space: nowrap;
     }
+  }
+}
+
+@media (max-width: 768px) {
+  .main-container {
+    display: block;
+    width: 100%;
+    margin: 0;
+  }
+
+  .sequencer-header,
+  .sequencer-scroll-container,
+  .export-button-container {
+    width: 100%;
+  }
+
+  .sequencer-scroll-container {
+    display: flex;
+    overflow-x: auto;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+    touch-action: pan-x;
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+
+  .tracks-name-container {
+    flex: 0 0 120px;
+    width: 120px;
+  }
+
+  .tracks-container {
+    flex: 0 0 max-content;
+    overflow: visible;
+    width: max-content;
+
+    article {
+      width: max-content;
+    }
+  }
+
+  .export-button-container {
+    margin-top: utils.$main-app-margin-size;
   }
 }
 

--- a/frontend/src/app/ui/components/sequencer/sequencer.component.ts
+++ b/frontend/src/app/ui/components/sequencer/sequencer.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, HostListener, Inject, OnDestroy, OnInit } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, HostListener, Inject, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { TranslatePipe } from '@ngx-translate/core';
 import { Subject, takeUntil, tap } from 'rxjs';
@@ -44,8 +44,10 @@ import { IManageBeatsToken } from "../../../infrastructure/injection-tokens/i-ma
   imports: [BpmInputComponent, SelectInputComponent, FormsModule, TranslatePipe, ExportAudioModalComponent, ExportMidiModalComponent, BrowseAudioSamplesModalComponent, NgOptimizedImage, DrumImagePipe, IconDarkModePipe, NgClass],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class SequencerComponent implements OnInit, OnDestroy {
+export class SequencerComponent implements AfterViewInit, OnInit, OnDestroy {
   private readonly destroy$ = new Subject<void>();
+  private readonly mobileTrackNamesWidth = 120;
+  @ViewChild('sequencerScrollContainer') private sequencerScrollContainer?: ElementRef<HTMLElement>;
   protected readonly Math = Math;
   protected readonly NumberOfSteps = NumberOfSteps;
   protected readonly AddTrackFeatureToggle = false;
@@ -71,6 +73,17 @@ export class SequencerComponent implements OnInit, OnDestroy {
     this.playerEvents.playPause$
       .pipe(takeUntil(this.destroy$))
       .subscribe(() => this.soundService.playPause());
+  }
+
+  ngAfterViewInit(): void {
+    this.scrollGridIntoView();
+  }
+
+  private scrollGridIntoView(): void {
+    const container = this.sequencerScrollContainer?.nativeElement;
+    if (!container) return;
+
+    requestAnimationFrame(() => container.scrollLeft = this.mobileTrackNamesWidth);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-misused-promises
@@ -129,6 +142,7 @@ export class SequencerComponent implements OnInit, OnDestroy {
     };
 
     this.soundService.setTracks(this.beat.tracks);
+    this.scrollGridIntoView();
   }
 
   private _applySteps(): void {


### PR DESCRIPTION
Resolved the mobile UI issue related to scrolling the drum grid and displaying track/drum names.

Changes Made
Added horizontal scrolling support for the drum grid on mobile devices.
Implemented a right-side pull/swipe interaction to reveal track/drum names.
Improved the responsive layout for smaller screen sizes.
Ensured existing drum grid interactions continue to work as expected.
Improved the overall usability and navigation of the drum grid on mobile devices.
This provides a smoother and more user-friendly experience when working with the drum grid on mobile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved mobile sequencer usability with responsive layout and horizontal touch scrolling.
  * Track names remain visible while browsing the sequencer grid on smaller screens.
  * The grid automatically positions itself correctly when tracks are loaded or updated.

* **Bug Fixes**
  * Synchronized scrolling between sequencer track names and the track grid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->