### PR TITLE
fix: make modal close button distinct from text

### DIFF
--- a/frontend/src/styles/modals/modal.base.scss
+++ b/frontend/src/styles/modals/modal.base.scss
@@ -37,18 +37,38 @@
 
 .close-btn {
   cursor: pointer;
-  background: transparent;
-  border: none;
-  color: inherit;
+  background: color-mix(in srgb, var(--textColor) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--textColor) 14%, transparent);
+  color: var(--textColor);
   font-size: 1.5rem;
-  font-weight: 600;
+  font-weight: 700;
   line-height: 1;
-  padding: 0.25rem 0.5rem;
-  margin-left: 0.5rem;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  margin-left: 12px;
+  border-radius: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    background-color 150ms ease,
+    border-color 150ms ease,
+    transform 100ms ease;
 }
 
 .close-btn:hover {
-  opacity: 0.7;
+  background: color-mix(in srgb, var(--textColor) 14%, transparent);
+  border-color: color-mix(in srgb, var(--textColor) 24%, transparent);
+}
+
+.close-btn:active {
+  transform: scale(0.96);
+}
+
+.close-btn:focus-visible {
+  outline: 2px solid #007bff;
+  outline-offset: 2px;
 }
 
 .modal-body {


### PR DESCRIPTION
﻿Fixes #531

The top-right close button (X) was blending with modal title text - transparent background, no border, opacity-only hover. It looked like part of title.

Changes:
- Distinct 36x36px hit area with centered flex layout
- Subtle background (8% textColor) and 1px border (14%) for contrast in light/dark themes
- Hover increases to 14% bg / 24% border instead of opacity fade
- Active press scale and focus-visible outline for accessibility
- Rounded 8px corners to separate from text

Before: transparent, opacity 0.7 on hover, no separation from header text.
After: boxed button with background/border, clearly tappable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Redesigned modal close buttons with a themed, bordered appearance and consistent 36px sizing.
  - Improved hover and press feedback with color transitions and a scale-down effect.
  - Added a visible focus outline for keyboard navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->