### PR TITLE
478 refacto move genre and beat select in parent component

### DIFF
--- a/frontend/src/app/ui/app.component.html
+++ b/frontend/src/app/ui/app.component.html
@@ -1,9 +1,24 @@
 <ngx-loading-bar></ngx-loading-bar>
+
+<ng-template #libraryControls>
+  <div class="library-controls">
+    <app-select-input [elements]="sequencerService.genresLabel"
+      [selectedElement]="sequencerService.vm$.getValue().genre" (selectChange)="genreChange($event)"
+      placeHolder="{{ 'chooseGenre' | translate }}">
+    </app-select-input>
+    <app-select-input [elements]="sequencerService.vm$.getValue().beats"
+      [selectedElement]="sequencerService.vm$.getValue().beat" (selectChange)="beatChange($event)"
+      placeHolder="{{ 'chooseBeat' | translate : { genre : sequencerService.vm$.getValue().genre } }}">
+    </app-select-input>
+  </div>
+</ng-template>
+
 @if (!isMobile()) {
 <main class="flex app-container">
   <img src="../../assets/images/title.svg" id="title-image" alt="Website Title" class="top-left-corner cursor-pointer"
     (click)="goToMainPage()" />
-  <section class="flex content">
+  <section class="flex content column">
+    <ng-container [ngTemplateOutlet]="libraryControls"></ng-container>
     <sequencer></sequencer>
   </section>
 </main>
@@ -13,7 +28,8 @@
 </footer>
 } @else if (isMobile() && isLandscape) {
 <main class="app-container">
-  <section class="flex content">
+  <section class="flex content column">
+    <ng-container [ngTemplateOutlet]="libraryControls"></ng-container>
     <sequencer></sequencer>
   </section>
 </main>

--- a/frontend/src/app/ui/app.component.scss
+++ b/frontend/src/app/ui/app.component.scss
@@ -29,6 +29,15 @@
   height: 100%;
 }
 
+.library-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+  max-width: 300px;
+  margin-bottom: 16px;
+}
+
 .column {
   flex-direction: column;
 }

--- a/frontend/src/app/ui/app.component.spec.ts
+++ b/frontend/src/app/ui/app.component.spec.ts
@@ -126,7 +126,9 @@ describe('AppComponent', () => {
     expect(vm.genre).toEqual(technoBeat.genre);
   });
 
-  it('should keep the current beat when an unknown beat is given', () => {
+  it('should keep the current beat when an unknown beat is given', async () => {
+    await waitForVm(x => x.beat === technoBeat.label);
+
     component.beatChange('does not exist');
 
     expect(service.vm$.getValue().beat).toEqual(technoBeat.label);

--- a/frontend/src/app/ui/app.component.spec.ts
+++ b/frontend/src/app/ui/app.component.spec.ts
@@ -1,0 +1,134 @@
+import { AppComponent } from './app.component';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { By } from '@angular/platform-browser';
+import { BreakpointObserver } from '@angular/cdk/layout';
+import { filter, firstValueFrom, of } from 'rxjs';
+import { Effect, Option } from 'effect';
+import { provideTranslateService } from '@ngx-translate/core';
+import { IManageBeatsToken } from '../infrastructure/injection-tokens/i-manage-beat.token';
+import { AUDIO_ENGINE } from '../infrastructure/injection-tokens/audio-engine.token';
+import { AUDIO_EXPORT } from '../infrastructure/injection-tokens/audio-export.token';
+import { IMIDI } from '../infrastructure/injection-tokens/i-midi.token';
+import {
+  AudioEngineAdapterFake
+} from '../infrastructure/adapters/audio-engine/audio-engine.adapter.fake';
+import { AudioExportAdapter } from '../infrastructure/adapters/audio-export/audio-export.adapter';
+import { MidiExportService } from '../infrastructure/adapters/midi-export/midi-exporter.service';
+import { SequencerService } from './services/sequencer/sequencer.service';
+import { SequencerViewModel } from './components/sequencer/sequencer.viewmodel';
+import { Beat } from '../domain/beat';
+import { BPM } from '../domain/bpm';
+import { Steps } from '../domain/steps';
+import { MidiDrumType } from '../domain/midi-drum-type';
+
+declare let SequencerEngine: any;
+declare let BeatLibrary: any;
+
+describe('AppComponent', () => {
+  let fixture: ComponentFixture<AppComponent>;
+  let component: AppComponent;
+  let service: SequencerService;
+
+  const technoBeat = { label: "techno", genre: "techno", filename: "techno" };
+  const secondTechnoBeat = { label: "techno2", genre: "techno", filename: "techno" };
+  const houseBeat = { label: "house", genre: "house", filename: "house" };
+
+  // dispatch() is queued and resolves outside of Angular's zone, so whenStable()
+  // is not enough : wait for the view model to carry the expected selection
+  const waitForVm = (predicate: (vm: SequencerViewModel) => boolean): Promise<SequencerViewModel> =>
+    firstValueFrom(service.vm$.pipe(filter(predicate)));
+
+  beforeEach(async () => {
+    spyOn(BeatLibrary, 'loadBeatsManifest').and.returnValue(
+      Promise.resolve([technoBeat, secondTechnoBeat, houseBeat])
+    );
+
+    SequencerEngine.reset();
+
+    const beatsMock = {
+      getBeatByFileName: jasmine.createSpy('getBeatByFileName').and.returnValue(
+        Effect.succeed({
+          label: "techno",
+          genre: "techno",
+          bpm: BPM(128),
+          beatsPerBar: 4,
+          subdivisionsPerBeat: 4,
+          numberOfBar: 1,
+          tracks: [
+            {
+              name: 'Snare',
+              filename: 'metal/snare.mp3',
+              steps: new Steps([true, true, true, true]),
+              isMuted: false,
+              midiNote: Option.some(MidiDrumType.ACOUSTIC_SNARE)
+            }
+          ]
+        } as Beat)
+      )
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [AppComponent],
+      providers: [
+        { provide: IManageBeatsToken, useValue: beatsMock },
+        { provide: AUDIO_ENGINE, useClass: AudioEngineAdapterFake },
+        { provide: AUDIO_EXPORT, useClass: AudioExportAdapter },
+        { provide: IMIDI, useClass: MidiExportService },
+        // force the desktop branch of the template, hidden on mobile by default
+        { provide: BreakpointObserver, useValue: { observe: () => of({ matches: true, breakpoints: {} }) } },
+        provideTranslateService({
+          lang: 'en',
+          fallbackLang: 'en'
+        }),
+        provideHttpClient()
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AppComponent);
+    component = fixture.componentInstance;
+    service = TestBed.inject(SequencerService);
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should render the genre select and the beat select', () => {
+    const selects = fixture.debugElement.queryAll(By.css('app-select-input'));
+
+    expect(selects.length).toBe(2);
+  });
+
+  it('should select the first genre of the library on init', async () => {
+    const vm = await waitForVm(x => x.genre === technoBeat.genre);
+
+    expect(vm.beat).toEqual(technoBeat.label);
+  });
+
+  it('should select the first beat of the genre when the genre changes', async () => {
+    component.genreChange(houseBeat.genre);
+
+    const vm = await waitForVm(x => x.genre === houseBeat.genre);
+
+    expect(vm.beat).toEqual(houseBeat.label);
+  });
+
+  it('should select the given beat when the beat changes', async () => {
+    component.beatChange(secondTechnoBeat.label);
+
+    const vm = await waitForVm(x => x.beat === secondTechnoBeat.label);
+
+    expect(vm.genre).toEqual(technoBeat.genre);
+  });
+
+  it('should keep the current beat when an unknown beat is given', () => {
+    component.beatChange('does not exist');
+
+    expect(service.vm$.getValue().beat).toEqual(technoBeat.label);
+  });
+});

--- a/frontend/src/app/ui/app.component.ts
+++ b/frontend/src/app/ui/app.component.ts
@@ -1,4 +1,4 @@
-import {Component, HostListener} from '@angular/core';
+import {Component, HostListener, OnInit} from '@angular/core';
 import {BreakpointObserver, Breakpoints} from '@angular/cdk/layout';
 import {ModeToggleService} from "./services/light-dark-mode/mode-toggle.service";
 import {Mode} from './services/light-dark-mode/mode-toggle.model';
@@ -6,16 +6,20 @@ import {toSignal} from "@angular/core/rxjs-interop";
 import {map} from "rxjs/operators";
 import {TranslatePipe} from "@ngx-translate/core";
 import {LoadingBarModule} from "@ngx-loading-bar/core";
+import {NgTemplateOutlet} from '@angular/common';
 import {SequencerComponent} from './components/sequencer/sequencer.component';
+import {SelectInputComponent} from './components/select-input/select-input.component';
+import {SequencerService} from './services/sequencer/sequencer.service';
+import {BeatMetadata} from 'src/types/engine';
 
 @Component({
     selector: 'app-root',
     templateUrl: './app.component.html',
     styleUrls: ['./app.component.scss'],
     standalone: true,
-    imports: [SequencerComponent, TranslatePipe, LoadingBarModule]
+    imports: [SequencerComponent, SelectInputComponent, NgTemplateOutlet, TranslatePipe, LoadingBarModule]
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
   isPortrait: boolean = false;
   isLandscape: boolean = false;
   mode: Mode = Mode.LIGHT;
@@ -29,9 +33,54 @@ export class AppComponent {
   );
 
   constructor(private readonly responsive: BreakpointObserver,
-              private readonly modeToggleService: ModeToggleService) {
+              private readonly modeToggleService: ModeToggleService,
+              public readonly sequencerService: SequencerService) {
     this.modeToggleService.modeChanged$.subscribe(x => this.mode = x);
     this.checkOrientation();
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  async ngOnInit(): Promise<void> {
+    await this.sequencerService.initialize();
+
+    const firstGenre = this.sequencerService.genresLabel[0];
+    if (firstGenre) {
+      this.genreChange(firstGenre);
+    }
+  }
+
+  genreChange(genre: string): void {
+    const beatsFromGenre = this.sequencerService.genres.get(genre);
+
+    if (!beatsFromGenre || beatsFromGenre.length === 0)
+      return;
+
+    this.selectBeat(beatsFromGenre[0]);
+  }
+
+  beatChange(beat: string): void {
+    const currentGenre = this.sequencerService.vm$.getValue().genre;
+    const beatsFromGenre = this.sequencerService.genres.get(currentGenre);
+
+    if (!beatsFromGenre)
+      return;
+
+    const beatToSelect = beatsFromGenre.find(x => x.label === beat);
+
+    this.selectBeat(beatToSelect);
+  }
+
+  selectBeat(beatToSelect: BeatMetadata | undefined): void {
+    if (!beatToSelect)
+      return;
+
+    void this.sequencerService.dispatch({
+      type: 'SELECT_BEAT',
+      payload: {
+        genre: beatToSelect.genre,
+        beat: beatToSelect.label
+      }
+    });
   }
 
   @HostListener('window:orientationchange', ['$event'])

--- a/frontend/src/app/ui/components/sequencer/sequencer.component.html
+++ b/frontend/src/app/ui/components/sequencer/sequencer.component.html
@@ -24,18 +24,6 @@
         </button>
       </div>
     </div>
-    <div class="label">
-      <app-select-input [elements]="sequencerService.genresLabel"
-        [selectedElement]="sequencerService.vm$.getValue().genre" (selectChange)="this.genreChange($event)"
-        placeHolder="{{ 'chooseGenre' | translate }}">
-      </app-select-input>
-    </div>
-    <div class="label">
-      <app-select-input [elements]="sequencerService.vm$.getValue().beats"
-        [selectedElement]="sequencerService.vm$.getValue().beat" (selectChange)="beatChange($event)"
-        placeHolder="{{ 'chooseBeat' | translate : { genre : sequencerService.vm$.getValue().genre } }}">
-      </app-select-input>
-    </div>
   </div>
   <div class="tracks-name-container">
     @for (track of beat.tracks; track track){

--- a/frontend/src/app/ui/components/sequencer/sequencer.component.scss
+++ b/frontend/src/app/ui/components/sequencer/sequencer.component.scss
@@ -47,10 +47,6 @@ $gap: 4px;
     }
   }
 
-  div+div {
-    margin-top: 8px;
-  }
-
   .bpm-input-group {
     align-items: center;
     gap: 16px;

--- a/frontend/src/app/ui/components/sequencer/sequencer.component.spec.ts
+++ b/frontend/src/app/ui/components/sequencer/sequencer.component.spec.ts
@@ -83,6 +83,13 @@ describe('SequencerComponent', () => {
     component = fixture.componentInstance;
     service = TestBed.inject(SequencerService);
 
+    // AppComponent owns the library bootstrap now, so the test has to arrange it
+    await service.initialize();
+    await service.dispatch({
+      type: 'SELECT_BEAT',
+      payload: { genre: beatMetaData.genre, beat: beatMetaData.label }
+    });
+
     fixture.detectChanges();
     await fixture.whenStable();
     fixture.detectChanges();
@@ -138,11 +145,11 @@ describe('SequencerComponent', () => {
       btn.nativeElement.classList.contains('active')
     ).length;
 
-    component.beatChange(secondBeatMetaData.label);
+    await service.dispatch({ type: 'SELECT_BEAT', payload: { genre: secondBeatMetaData.genre, beat: secondBeatMetaData.label } });
     await fixture.whenStable();
     fixture.detectChanges();
 
-    component.beatChange(beatMetaData.label);
+    await service.dispatch({ type: 'SELECT_BEAT', payload: { genre: beatMetaData.genre, beat: beatMetaData.label } });
     await fixture.whenStable();
     fixture.detectChanges();
 

--- a/frontend/src/app/ui/components/sequencer/sequencer.component.ts
+++ b/frontend/src/app/ui/components/sequencer/sequencer.component.ts
@@ -26,7 +26,6 @@ import { DrumImagePipe } from '../../pipes/drum-image.pipe';
 import { IconDarkModePipe } from '../../pipes/icon-dark-mode.pipe';
 
 import { BpmInputComponent } from '../bpm-input/bpm-input.component';
-import { SelectInputComponent } from '../select-input/select-input.component';
 import { ExportAudioModalComponent } from '../modals/export-audio-modal/export-audio-modal.component';
 import { ExportMidiModalComponent } from '../modals/export-midi-modal/export-midi-modal.component';
 import { BrowseAudioSamplesModalComponent } from '../modals/browse-audio-samples-modal/browse-audio-samples-modal.component';
@@ -39,7 +38,7 @@ import { BeatMetadata } from 'src/types/engine';
   standalone: true,
   templateUrl: './sequencer.component.html',
   styleUrls: ['./sequencer.component.scss'],
-  imports: [BpmInputComponent, SelectInputComponent, FormsModule, TranslatePipe, ExportAudioModalComponent, ExportMidiModalComponent, BrowseAudioSamplesModalComponent, NgOptimizedImage, DrumImagePipe, IconDarkModePipe, NgClass],
+  imports: [BpmInputComponent, FormsModule, TranslatePipe, ExportAudioModalComponent, ExportMidiModalComponent, BrowseAudioSamplesModalComponent, NgOptimizedImage, DrumImagePipe, IconDarkModePipe, NgClass],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class SequencerComponent implements OnInit, OnDestroy {
@@ -70,8 +69,7 @@ export class SequencerComponent implements OnInit, OnDestroy {
       .subscribe(() => this.soundService.playPause());
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
-  async ngOnInit(): Promise<void> {
+  ngOnInit(): void {
     this.sequencerService.state$
       .pipe(
         tap(state => {
@@ -102,13 +100,6 @@ export class SequencerComponent implements OnInit, OnDestroy {
         takeUntil(this.destroy$)
       )
       .subscribe();
-
-    await this.sequencerService.initialize();
-
-    const firstGenre = this.sequencerService.genresLabel[0];
-    if (firstGenre) {
-      this.genreChange(firstGenre);
-    }
   }
 
   private _applyBeat(beatMeta: BeatMetadata, stateGenre: string, stateTempo: number, beatsPerBar: number, subdivisionsPerBeat: number, numberOfBars: number): void {
@@ -132,40 +123,6 @@ export class SequencerComponent implements OnInit, OnDestroy {
     const vmTracks = this.sequencerService.vm$.getValue().tracks;
     this.soundService.syncTracks(vmTracks);
     this.beat = { ...this.beat, tracks: vmTracks };
-  }
-
-  genreChange(genre: string): void {
-    const beatsFromGenre = this.sequencerService.genres.get(genre);
-
-    if (!beatsFromGenre || beatsFromGenre.length === 0)
-      return;
-
-    this.selectBeat(beatsFromGenre[0]);
-  }
-
-  beatChange(beat: string): void {
-    const currentGenre = this.sequencerService.vm$.getValue().genre;
-    const beatsFromGenre = this.sequencerService.genres.get(currentGenre);
-
-    if (!beatsFromGenre)
-      return;
-
-    const beatToSelect = beatsFromGenre.find(x => x.label === beat);
-
-    this.selectBeat(beatToSelect);
-  }
-
-  selectBeat(beatToSelect: BeatMetadata | undefined): void {
-    if (!beatToSelect)
-      return;
-
-    void this.sequencerService.dispatch({
-      type: 'SELECT_BEAT',
-      payload: {
-        genre: beatToSelect.genre,
-        beat: beatToSelect.label
-      }
-    });
   }
 
   dragState: { readonly trackName: string; readonly from: number; readonly to: number; readonly value: boolean } | null = null;


### PR DESCRIPTION
Closes #478

## Why

`SequencerComponent` was doing two jobs: rendering the sequencer **and** managing the beat library. This moves the library part out, so the sequencer is only about the grid.

## What moved

From `sequencer.component.*` to `app.component.*`:

- the two `<app-select-input/>` controls
- `genreChange`, `beatChange` and `selectBeat`, unchanged
- the initial library load from `ngOnInit` (`initialize()` + selecting the first genre), since it is library management rather than sequencing

No `@Input`/`@Output` wiring was needed: `SequencerService` is `providedIn: 'root'`, so both components already read the same genre/beat state and dispatch through the same service — option 2 of the issue.

`SequencerComponent` no longer imports `SelectInputComponent`, and its `ngOnInit` is no longer `async`, so the `no-misused-promises` disable moved along with the code it was covering.

The two selects are declared once in an `<ng-template>` and projected into both the desktop and the mobile-landscape branch, to avoid duplicating them.

## One visible change, on purpose

The selects used to sit in **column 2** of the sequencer's own grid, aligned with the step grid. That alignment comes from `.main-container`'s `grid-template-columns: max-content auto`, where column 1 is the track-name column and its width depends on the current beat. A parent component cannot reproduce it, so the selects are now centered above the sequencer instead.

| before | after |
|---|---|
| play/BPM/undo/redo, then genre, then beat — all inside the sequencer header | genre and beat above, then the sequencer with play/BPM/undo/redo |

Happy to take a different placement if you prefer — or to keep the old look via content projection, which would leave a header slot in the sequencer.

## Checks

- `npm run test-ci` — 82 passing, 4 pre-existing skipped
- `npm run test-vitest-coverage` — 10 passing
- `npm run lint` — 0 errors, 7 warnings (same as `main`, same three files)
- i18n keys untouched: `chooseGenre` and `chooseBeat` moved verbatim, including the `{{ genre }}` parameter
- checked by hand in the browser: switching genre reloads the beat list and the tracks, switching beat reloads the grid, undo/redo still restore both selects

`app.component.spec.ts` did not exist, so it is added here to keep the moved logic covered: first genre on init, genre change, beat change, unknown beat, and that both selects render. `BreakpointObserver` is stubbed to reach the desktop branch. Since `dispatch()` is queued and resolves outside of Angular's zone, the tests wait on the view model rather than on `whenStable()`.

The sequencer spec used to get its beat for free from the component's `ngOnInit`, so it now arranges that bootstrap itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Genre and beat selection controls are now available in a shared library controls area across desktop and mobile layouts.
  * Selecting a genre or beat updates the sequencer’s active beat.
  * Improved vertical layout and spacing for the library controls.

* **Bug Fixes**
  * Selecting an unknown beat now preserves the currently selected beat.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
